### PR TITLE
feat: add issue/pr templates and oss md files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,6 +35,7 @@ labels: bug
 - OS Name: [e.g., Ubuntu]
 - OS Version: [e.g., 20.04]
 - Software Version: [e.g., 1.0.4-beta2]
+- Other environment/deployment details and/or version information: [e.g., docker/k8s context]
 
 ## Additional context
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,20 +18,24 @@ labels: bug
 
 <!-- What commands in order should someone run to reproduce your problem? -->
 
-## Expected behavior
+## Expected Behavior
 
 <!-- A clear and concise description of what you expected to happen -->
 
+## Actual Observed Behavior
+
+<!-- A clear and concise description of what you observed happening -->
+
 ## Screenshots
 
-<!-- If applicable, add screenshots to help explain your problem. -->
+<!-- If applicable, add screenshots to help explain your problem -->
 
 ## Version
 
-- OS Name: [e.g. Ubuntu]
-- OS Version [e.g. 20.04]
-- CLI Version (output of `topos --version`)
+- OS Name: [e.g., Ubuntu]
+- OS Version: [e.g., 20.04]
+- Software Version: [e.g., 1.0.4-beta2]
 
 ## Additional context
 
-<!-- Add any other context about the problem here. -->
+<!-- Add any other context about the problem here -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Create a report to help us solve bugs!
+labels: bug
+---
+
+<!--
+        ✰  Thanks for opening an issue! ✰
+  Before submitting please review the template.
+  Please also ensure that this is not a duplicate issue :)
+-->
+
+## Summary
+
+<!-- Concisely describe the issue -->
+
+## Steps to Reproduce
+
+<!-- What commands in order should someone run to reproduce your problem? -->
+
+## Expected behavior
+
+<!-- A clear and concise description of what you expected to happen -->
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Version
+
+- OS Name: [e.g. Ubuntu]
+- OS Version [e.g. 20.04]
+- CLI Version (output of `topos --version`)
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Create a report to help us solve bugs!
+labels: bug
+---
+
+<!--
+        ✰  Thanks for opening an issue! ✰
+  Before submitting please review the template.
+  Please also ensure that this is not a duplicate issue :)
+-->
+
+## Is your proposal related to a problem?
+
+<!--
+  Provide a clear and concise description of what the problem is.
+  For example, "I'm always frustrated when..."
+-->
+
+## Describe the solution you'd like
+
+<!--
+  Provide a clear and concise description of what you want to happen.
+-->
+
+## Describe alternatives you've considered
+
+<!--
+  Let us know about other solutions you've tried or researched.
+-->
+
+## Additional context
+
+<!--
+  Is there anything else you can add about the proposal?
+  You might want to link to related issues here, if you haven't already.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
-name: Bug Report
-about: Create a report to help us solve bugs!
-labels: bug
+name: Feature Request
+about: Propose a new feature!
+labels: feature request
 ---
 
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+# Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B
+
+**Test Configuration**:
+
+- Firmware version:
+- Hardware:
+- Toolchain:
+- SDK:
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,6 +34,6 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at info@toposware.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,200 @@
+# Contributing
+
+This repository operates an open contributor model where anyone is
+welcome to contribute towards development in the form of peer review, testing
+and patches. This document explains the practical process and guidelines for
+contributing.
+
+## Contributor Workflow
+
+The codebase is maintained using the "contributor workflow" where everyone
+without exception contributes patch proposals using "pull requests" (PRs). This
+facilitates social contribution, easy testing and peer review.
+
+To contribute a patch, the workflow is as follows:
+
+1. Clone the repository
+2. Create topic branch
+3. Commit patches
+
+### Committing Patches
+
+In general, [commits should be atomic](https://en.wikipedia.org/wiki/Atomic_commit#Atomic_commit_convention)
+and diffs should be easy to read. For this reason, do not mix any formatting
+fixes or code moves with actual code changes.
+
+Make sure each individual commit is hygienic: that it builds successfully on its
+own without warnings, errors, regressions, or test failures.
+
+Commit messages should be verbose by default consisting of a short subject line
+(50 chars max), a blank line and detailed explanatory text as separate
+paragraph(s), unless the title alone is self-explanatory (like "Correct typo
+in bar/foo.rs") in which case a single title line is sufficient. Commit messages should be
+helpful to people reading your code in the future, so explain the reasoning for
+your decisions. Further explanation [here](https://chris.beams.io/posts/git-commit/).
+
+Commit messages should follow the [Conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
+and may use optional scope as defined in next section.
+
+If a particular commit references another issue, please add the reference. For
+example: `refs #1234` or `fixes #4321`. Using the `fixes` or `closes` keywords
+will cause the corresponding issue to be closed when the pull request is merged.
+
+Commit messages should never contain any `@` mentions (usernames prefixed with "@").
+
+Please refer to the [Git manual](https://git-scm.com/doc) for more information
+about Git.
+
+- Push changes to your branch
+- Create pull request
+
+### Scopes
+
+Scopes are used to define which component or area if affected by the changes.
+Scopes are optional but recommended if applicable. Some predefined scope exists
+but you can create new if necessary or if no predefined scope match what you are
+changing. By convention it is better to have a single scope but multiple scopes
+can be provided, separated by comma.
+
+Here's a list of predefined scopes:
+
+- `protocol` for changes to protocol critical code
+- `doc` for changes to the documentation
+- `log` for changes to log messages
+- `net` or `p2p` for changes to the peer-to-peer network code
+- `refactor` for structural changes that do not change behavior
+- `rpc` or `rest` for changes to the RPC or REST APIs
+- `script` for changes to the scripts and tools
+- `test`, `qa` or `ci` for changes to the unit tests, QA tests or CI code
+- `config` for changes to cargo, toml, crates organization
+- _package name_ for changes related to a particular package
+
+Commit message examples:
+
+    feat(protocol): Fetch the samples from the double echo
+    fix(net): Adapt the peer discovery with kademlia
+    chore(log): Fix typo in log message
+
+### Creating the Pull Request
+
+The title of the pull request should follow the [Conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
+and can define a scope as well (see section above).
+
+The body of the pull request should contain sufficient description of _what_ the
+patch does, and even more importantly, _why_, with justification and reasoning.
+
+The description for a new pull request should not contain any `@` mentions. The
+PR description will be included in the commit message when the PR is merged and
+any users mentioned in the description will be annoyingly notified each time a
+fork copies the merge. Instead, make any username mentions in a
+subsequent comment to the PR.
+
+### Address Feedback
+
+At this stage, one should expect comments and review from other contributors. You
+can add more commits to your pull request by committing them locally and pushing
+to your branch.
+
+You are expected to reply to any review comments before your pull request is
+merged. You may update the code or reject the feedback if you do not agree with
+it, but you should express so in a reply. If there is outstanding feedback and
+you are not actively working on it, your pull request may be closed.
+
+Please refer to the [peer review](#peer-review) section below for more details.
+
+### Squashing Commits
+
+If your pull request contains fixup commits (commits that change the same line of code repeatedly) or too fine-grained
+commits, you may be asked to [squash](https://git-scm.com/docs/git-rebase#_interactive_mode) your commits
+before it will be reviewed. The basic squashing workflow is shown below.
+
+    git checkout your_branch_name
+    git rebase -i HEAD~n
+    # n is normally the number of commits in the pull request.
+    # Set commits (except the one in the first line) from 'pick' to 'squash', save and quit.
+    # On the next screen, edit/refine commit messages.
+    # Save and quit.
+    git push -f # (force push to GitHub)
+
+Please update the resulting commit message, if needed. It should read as a
+coherent message. In most cases, this means not just listing the interim
+commits.
+
+Please refrain from creating several pull requests for the same change.
+Use the pull request that is already open (or was created earlier) to amend
+changes. This preserves the discussion and review that happened earlier for
+the respective change set.
+
+The length of time required for peer review is unpredictable and will vary from
+pull request to pull request.
+
+### Rebasing Changes
+
+When a pull request conflicts with the target branch, you may be asked to rebase it on top of the current target branch.
+
+    git fetch https://github.com/toposware/tce  # Fetch the latest upstream commit
+    git rebase FETCH_HEAD  # Rebuild commits on top of the new base
+
+This project aims to have a clean git history, where code changes are only made in non-merge commits. This simplifies
+auditability because merge commits can be assumed to not contain arbitrary code changes.
+
+After a rebase, reviewers are encouraged to sign off on the force push.
+
+### Merge of the pull request
+
+The [Squash and Merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits) is used to integrate the changes into the main branch.
+
+## Pull Request Philosophy
+
+Patch sets should always be focused. For example, a pull request could add a
+feature, fix a bug, or refactor code; but not a mixture. Please also avoid super
+pull requests which attempt to do too much, are overly large, or overly complex
+as this makes review difficult.
+
+### Features
+
+When adding a new feature, thought must be given to the long term technical debt
+and maintenance that feature may require after inclusion. Before proposing a new
+feature that will require maintenance, please consider if you are willing to
+maintain it (including bug fixing). If features get orphaned with no maintainer
+in the future, they may be removed by the Repository Maintainer.
+
+### Refactoring
+
+Refactoring is a necessary part of any software project's evolution. The
+following guidelines cover refactoring pull requests for the project.
+
+There are three categories of refactoring: code-only moves, code style fixes, and
+code refactoring. In general, refactoring pull requests should not mix these
+three kinds of activities in order to make refactoring pull requests easy to
+review and uncontroversial. In all cases, refactoring PRs must not change the
+behavior of code within the pull request (bugs must be preserved as is).
+
+### Peer Review
+
+Code review is an important part of the development process.
+**As a reviewer proposing changes, you must request for those changes by choosing "[Request for changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews)" when submitting your review.**
+**In particular, you must not Approve the PR before acknowledgement of the changes that you requested.**
+
+#### Code Review
+
+The following language is used within pull request comments:
+
+- "I have tested the code", involving change-specific manual testing in
+  addition to running the unit, functional, or fuzz tests, and in case it is
+  not obvious how the manual testing was done, it should be described;
+- "I have not tested the code, but I have reviewed it and it looks
+  OK, I agree it can be merged";
+- A "nit" refers to a trivial, often non-blocking issue.
+
+## Copyright
+
+By contributing to this repository, you agree to license your work under the MIT license. Any work contributed where you are not the original author must contain its license header with the original author(s) and source.
+
+## Changes to this arrangement
+
+This is an experiment and feedback is welcome! This document may also be subject to pull-requests or changes by contributors where you believe you have something valuable to add or change.
+
+## Heritage
+
+Adapted from the contributing guidelines for the [bitcoin core](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md) repository.


### PR DESCRIPTION
## Before
Issue/PR templates and CONTRIBUTING/CODE_OF_CONDUCT are manually added to every and each public repository of the company.

## After
We use the `.github` repository to contain templates and generic md files so that they can propagate to all repositories.